### PR TITLE
bot: add plugin option to receive all messages.

### DIFF
--- a/bot/command.go
+++ b/bot/command.go
@@ -12,6 +12,7 @@ type Command struct {
 	Pub     bool    // Command can be accessed publicly on a channel.
 	Priv    bool    // Command can be accessed privately in query.
 	Hidden  bool    // Hide command from list of all available commands.
+	All     bool    // Send all messages to Handler.
 }
 
 // String formats a command with its attributes for display in help.
@@ -25,6 +26,9 @@ func (c *Command) String() string {
 	}
 	if c.Hidden {
 		opts = append(opts, "hidden")
+	}
+	if c.All {
+		opts = append(opts, "all")
 	}
 	return fmt.Sprintf("%s (%s)", c.Help, strings.Join(opts, "+"))
 }


### PR DESCRIPTION
Allows plugins to passively consume messages without being directly
addressed.
